### PR TITLE
Fix qmd URL to github.com/tobi/qmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This removes the service, CLI, and source files. Your vault data is preserved.
 
 ## Optional: QMD Integration
 
-If you have [qmd](https://github.com/amir-arad/qmd) installed for semantic search, enable it in config:
+If you have [qmd](https://github.com/tobi/qmd) installed for semantic search, enable it in config:
 
 ```toml
 [qmd]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,7 @@ session_timeout_minutes = 30  # default
 
 ### QMD Settings
 
-[QMD](https://github.com/amir-arad/qmd) integration for semantic search.
+[QMD](https://github.com/tobi/qmd) integration for semantic search.
 
 ```toml
 [qmd]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ When you work with Claude Code, valuable insights emerge: debugging techniques, 
 | Dependency | Purpose |
 |------------|---------|
 | [Claude CLI](https://claude.ai/download) | Required for knowledge synthesis. Without it, only session logging works. |
-| [qmd](https://github.com/amir-arad/qmd) | Semantic search for better synthesis context. Helps Claude understand your existing notes. |
+| [qmd](https://github.com/tobi/qmd) | Semantic search for better synthesis context. Helps Claude understand your existing notes. |
 | pandoc | Required for document ingestion (PDF/DOCX support) |
 
 ## Installation

--- a/docs/qmd-integration.md
+++ b/docs/qmd-integration.md
@@ -1,6 +1,6 @@
 # QMD Integration
 
-Claude Note integrates with [qmd](https://github.com/amir-arad/qmd) for semantic search, dramatically improving synthesis quality and note routing.
+Claude Note integrates with [qmd](https://github.com/tobi/qmd) for semantic search, dramatically improving synthesis quality and note routing.
 
 ## What is QMD?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -381,7 +381,7 @@ ps aux | grep "claude-note worker"
 
 ```bash
 # Install qmd
-# See: https://github.com/amir-arad/qmd
+# See: https://github.com/tobi/qmd
 
 # Verify installation
 which qmd

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ if command -v qmd &>/dev/null; then
 else
     echo -e "  ${YELLOW}!${NC} qmd not found (semantic search disabled)"
     echo "    Synthesis will work but without vault context."
-    echo "    Install qmd for better results: https://github.com/amir-arad/qmd"
+    echo "    Install qmd for better results: https://github.com/tobi/qmd"
     echo
     read -p "    Continue without qmd? [Y/n] " CONTINUE_NO_QMD
     if [[ "$CONTINUE_NO_QMD" =~ ^[Nn] ]]; then


### PR DESCRIPTION
## Summary
- Fixed incorrect qmd GitHub URL across all documentation
- Changed from `github.com/amir-arad/qmd` to `github.com/tobi/qmd`

## Files changed
- README.md
- install.sh
- docs/getting-started.md
- docs/qmd-integration.md
- docs/configuration.md
- docs/troubleshooting.md